### PR TITLE
Add method runOnMainSync()

### DIFF
--- a/sample/src/androidTest/java/com/a21buttons/fragmenttestrule/sample/FragmentWithoutActivityDependencyTest.java
+++ b/sample/src/androidTest/java/com/a21buttons/fragmenttestrule/sample/FragmentWithoutActivityDependencyTest.java
@@ -9,6 +9,7 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 public class FragmentWithoutActivityDependencyTest {
@@ -22,5 +23,17 @@ public class FragmentWithoutActivityDependencyTest {
         onView(withText(R.string.button)).perform(click());
 
         onView(withText(R.string.button_clicked)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void callMethodOnFragmentUnderTest() throws Exception {
+        fragmentTestRule.runOnMainSync(new FragmentTestRule.Runner<FragmentWithoutActivityDependency>() {
+            @Override
+            public void run(FragmentWithoutActivityDependency fragment) {
+                fragment.setText("Welcome!");
+            }
+        });
+
+        onView(withId(R.id.textView)).check(matches(withText("Welcome!")));
     }
 }

--- a/sample/src/main/java/com/a21buttons/fragmenttestrule/sample/FragmentWithoutActivityDependency.java
+++ b/sample/src/main/java/com/a21buttons/fragmenttestrule/sample/FragmentWithoutActivityDependency.java
@@ -10,11 +10,13 @@ import android.widget.TextView;
 
 public class FragmentWithoutActivityDependency extends Fragment {
 
+    private TextView textView;
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_a, container, false);
-        final TextView textView = view.findViewById(R.id.textView);
+        textView = view.findViewById(R.id.textView);
 
         view.findViewById(R.id.button).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -25,4 +27,9 @@ public class FragmentWithoutActivityDependency extends Fragment {
 
         return view;
     }
+
+    public void setText(String text) {
+        textView.setText(text);
+    }
+
 }


### PR DESCRIPTION
Currently, to call methods on the tested fragment we have to do:

```java
try {
  fragmentTestRule.runOnUiThread(() -> fragmentRule.getFragment().showProgress());
} catch (Throwable throwable) {
  throwable.printStackTrace();
}
```

With this new method we cut all this to:
```java
fragmentTestRule.runOnMainSync(fragment -> fragment.showProgress());
```
In addition to being more legible and straightforward, using `runOnMainSync` is preferable over `runOnUiThread` because it waits for completion. (See https://stackoverflow.com/a/19427987/4034572 for more on this.)

I've copied this idea from Novoda's `ViewTestRule`: https://github.com/novoda/spikes/blob/master/espresso-support/core/src/main/java/com/novoda/espresso/ViewTestRule.java#L30

I've spent some time trying to write a decent javadoc, but we can tweak it you want.